### PR TITLE
Add User folder, terminal.json and User.md

### DIFF
--- a/User/User.md
+++ b/User/User.md
@@ -1,0 +1,16 @@
+# User folder "settings.json" file
+## Adding a w64devkit terminal (Alt-J) to your VSCode terminal Launch Profiles.
+1. Navigate to `%userprofile%\AppData\Roaming\Code\User` folder
+2. Open the `settings.json` file there
+3. Copy the **"w64DevKit":** json object in the `terminal.json` file here, and paste it into the `terminal.integrated.profiles.windows` object in your `settings.json` file.
+4.   `!!!MAKE A BACKUP FIRST!!!` If you are having issues getting it to work, you could just copy the entire contents of `terminal.json` file and paste it over the contents of your `settings.json` file. It is actually a copy of a `settings.json` file.
+5. Don't forget to save the file afterward.
+
+That's pretty much it if you installed Raylib in the default location.  If not, just update the json value associated with the  `"Path":` name you pasted to point to your `w64devkit\bin` folder.
+
+Some final notes:
+
+- After starting VSCode, press ***Alt-J*** to bring up your default terminal.
+- You should see tabs at the top of the terminal with **OUTPUT**, **DEBUG CONSOLE**, and **TERMINAL** among others.  Make sure you're on the **TERMINAL** tab.
+- To the right of that, you should see your current terminal listed and a dropdown arrow for *Launch Profile*.  Click *Launch Profile* and you should see the ***w64devkit*** terminal listed.  Click it to launch it.
+

--- a/User/terminal.json
+++ b/User/terminal.json
@@ -1,0 +1,29 @@
+{
+    "workbench.colorTheme": "Default Dark Modern",
+    "editor.stickyScroll.enabled": false,
+    "security.workspace.trust.untrustedFiles": "open",
+    "terminal.integrated.profiles.windows": {
+        "Command Prompt": {
+        "path": [
+        "${env:windir}\\Sysnative\\cmd.exe",
+        "${env:windir}\\System32\\cmd.exe"
+        ],
+        "args": [],
+        "icon": "terminal-cmd"
+        },
+
+        "w64DevKit": {
+        "path": "C:\\raylib\\w64devkit\\bin\\sh.exe",
+        "args": [],
+        "env": {
+            "PATH": "${env:PATH}C:\\raylib\\w64devkit\\bin"
+        },
+        "icon": "terminal-linux"
+        }
+    },
+    "terminal.integrated.tabs.defaultColor": "terminal.ansiGreen",
+    "editor.rulers": [    
+    ],
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    "makefile.configureOnOpen": true
+}

--- a/main.code-workspace
+++ b/main.code-workspace
@@ -53,6 +53,6 @@
 			"typeinfo": "cpp"
 		},
 		"git.autoRepositoryDetection": false,
-		"git.enabled": false
+		"git.enabled": true
 	}
 }


### PR DESCRIPTION
Adds the w64devkit shell to available terminals in VS Code by modifying the %USERPROFILE%\AppData\Roaming\Code\User\settings.json file.

Created a User folder
Added terminal.json to User folder (a basic copy of settings.json)
Added User.md to User folder
